### PR TITLE
Make Redis Value Serializer configurable through the RedisTemplate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 test {


### PR DESCRIPTION
* on construction of the MultiLevelCache, the RedisCacheConfiguration
  is configured with the Value Serializer from the RedisTemplate